### PR TITLE
Replace JsonProperty annotation with POJO setters in Java API model

### DIFF
--- a/election-api-java/src/main/java/bbc/news/elections/model/ApiResponse.java
+++ b/election-api-java/src/main/java/bbc/news/elections/model/ApiResponse.java
@@ -1,8 +1,11 @@
 package bbc.news.elections.model;
 
 public class ApiResponse {
-    private final String error;
-    private final String message;
+    private String error;
+    private String message;
+
+    public ApiResponse() {
+    }
 
     public ApiResponse(String error, String message) {
         this.error = error;
@@ -15,5 +18,13 @@ public class ApiResponse {
 
     public String getMessage() {
         return message;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 }

--- a/election-api-java/src/main/java/bbc/news/elections/model/ConstituencyResult.java
+++ b/election-api-java/src/main/java/bbc/news/elections/model/ConstituencyResult.java
@@ -1,26 +1,14 @@
 package bbc.news.elections.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public class ConstituencyResult {
-    private final Integer id;
-    private final String name;
-    private final Integer seqNo;
-    private final List<PartyResult> partyResults;
+    private Integer id;
+    private String name;
+    private Integer seqNo;
+    private List<PartyResult> partyResults;
 
-    public ConstituencyResult(
-            // JsonProperty annotations required for Jackson deserialisation during testing
-            @JsonProperty("id")  Integer id,
-            @JsonProperty("name")  String name,
-            @JsonProperty("seqNo")  Integer seqNo,
-            @JsonProperty("partyResults")  List<PartyResult> partyResults)
-    {
-        this.id = id;
-        this.name = name;
-        this.seqNo = seqNo;
-        this.partyResults = partyResults;
+    public ConstituencyResult() {
     }
 
     public Integer getId() { return id; }
@@ -30,4 +18,20 @@ public class ConstituencyResult {
     public Integer getSeqNo() { return seqNo; }
 
     public List<PartyResult> getPartyResults() { return partyResults; }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setSeqNo(Integer seqNo) {
+        this.seqNo = seqNo;
+    }
+
+    public void setPartyResults(List<PartyResult> partyResults) {
+        this.partyResults = partyResults;
+    }
 }

--- a/election-api-java/src/main/java/bbc/news/elections/model/PartyResult.java
+++ b/election-api-java/src/main/java/bbc/news/elections/model/PartyResult.java
@@ -1,23 +1,13 @@
 package bbc.news.elections.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.math.BigDecimal;
 
 public class PartyResult {
-   private final String party;
-   private final Integer votes;
-   private final BigDecimal share;
+   private String party;
+   private Integer votes;
+   private BigDecimal share;
 
-   public PartyResult(
-           // JsonProperty annotations required for Jackson deserialisation during testing
-           @JsonProperty("party")  String party,
-           @JsonProperty("votes")  Integer votes,
-           @JsonProperty("share")  BigDecimal share)
-   {
-      this.party = party;
-      this.votes = votes;
-      this.share = share;
+   public PartyResult() {
    }
 
    public String getParty() { return party; }
@@ -25,6 +15,18 @@ public class PartyResult {
    public Integer getVotes() { return votes; }
 
    public BigDecimal getShare() { return share; }
+
+   public void setParty(String party) {
+      this.party = party;
+   }
+
+   public void setVotes(Integer votes) {
+      this.votes = votes;
+   }
+
+   public void setShare(BigDecimal share) {
+      this.share = share;
+   }
 }
 
 


### PR DESCRIPTION
## What?
Remove the JsonProperty annotation and use fasterxml/jackson to serialise/deserialise model classes based on getters/setters of fields.

## Why?
In a previous change, the Java API assessment was modified to remove reference to the lombok annotations that provided builder/property functionality. In the same change, the JsonProperty annotation was introduced to provide Serialisation/Deserialisation to JSON. To further reduce the overhead and prior knowledge required by interview candidates, it would be an improvement to remove the need for the JsonProperty annotation and rely on plain Java objects where possible.
