### PR TITLE
Adds maven build output directory to .gitignore

### DIFF
--- a/election-api-java/.gitignore
+++ b/election-api-java/.gitignore
@@ -19,3 +19,4 @@
 .gradle/
 build/
 out/
+target/


### PR DESCRIPTION
The target directory contains the build artifacts from the Maven build
and should not be under version control. The gradle output directory
(build) is already ignored. If we are going to support both build
tools we should have the repository configured in the same way for each.

## What?
Adds `target` directory to `.gitignore` 

## Why?
It shouldn't be under version control and adding it to the ignore list makes the maven build more consistent with the gradle one.
