### PR TITLE
Feedback action from20220623 centre

### DIFF
--- a/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
+++ b/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
@@ -16,25 +16,25 @@ import java.util.Map;
 @RestController
 public class ResultsController {
 
-    private final ResultService results;
+    private final ResultService resultService;
 
     public ResultsController(ResultService resultService) {
-        this.results = resultService;
+        this.resultService = resultService;
     }
 
     @GetMapping("/result/{id}")
     ConstituencyResult getResult(@PathVariable Integer id) {
-        ConstituencyResult result = results.GetResult(id);
+        ConstituencyResult result = resultService.GetResult(id);
         if (result == null) {
             throw new ResultNotFoundException(id);
         }
-        return results.GetResult(id);
+        return resultService.GetResult(id);
     }
 
     @PostMapping("/result")
     ResponseEntity<String> newResult(@RequestBody ConstituencyResult result) {
         if (result.getId() != null) {
-            results.NewResult(result);
+            resultService.NewResult(result);
             return ResponseEntity.created(URI.create("/result/"+result.getId())).build();
         }
         return ResponseEntity.badRequest().body("Id was null");

--- a/election-api-java/src/main/java/bbc/news/elections/model/Scoreboard.java
+++ b/election-api-java/src/main/java/bbc/news/elections/model/Scoreboard.java
@@ -1,5 +1,5 @@
 package bbc.news.elections.model;
 
 public class Scoreboard {
-    // To be filled in
+
 }


### PR DESCRIPTION
## What / Why

* Remove comment from `Scoreboard` model that misled candidate into thinking they could only modify that file, for greater clarity of exercise.
* Rename `results` property  to `resultsService` as `result` and `results` could be interpreted as return variables from methods, and having a property of that name might be confusing.
