### PR TITLE
Python: make get_result method always return dict

### DIFF
--- a/election-api-python/src/results_service.py
+++ b/election-api-python/src/results_service.py
@@ -3,9 +3,9 @@ class ResultStore:
     def __init__(self) -> None:
         self.store: list[dict] = []
     
-    def get_result(self, id_to_get) -> str:
+    def get_result(self, id_to_get) -> dict:
         result: list[dict] = list(filter(lambda result: result['id'] == int(id_to_get), self.store))
-        return f"No result with id {id_to_get} found." if len(result) < 1 else result[0]
+        return result[0] if len(result) > 0 else {}
 
     def new_result(self, result) -> None:
         self.store.append(result)


### PR DESCRIPTION
## What?
This change only applies to the Python API assessment. Changes the `get_result` method of the result store to always return a dictionary object. When `get_result` is called with an id not present in the store, return an empty dict rather than an error string.

## Why?
The current return type annotation of the method, `str` is misleading as the method can return both a `str` and a `dict`. Changing the return type annotation and the type of the actual return value to only `dict` makes this method easier to understand for participants.

I think that participants are unlikely to hit the scenario where they call `get_result` with an id that is not present and that this change is worth sacrificing the error message they'd get. 
