### PR TITLE
Fix typos around the number of effective voting MPs in the golang and…

### DIFF
--- a/election-api-golang/tasks.md
+++ b/election-api-golang/tasks.md
@@ -11,7 +11,7 @@ For each constituency a winner can be declared:
 Someone wins in the UK if they receive half of the constituency seats in Parliament (325).
 So if a party has received 325 or more seats it can be declared the winner overall.
 
-Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 349.
+Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 649.
 
 The scoreboard should show:
 - The seats for each party

--- a/election-api-scala/tasks.md
+++ b/election-api-scala/tasks.md
@@ -10,7 +10,7 @@ For each constituency a winner can be declared:
 Someone wins in the UK if they receive half of the constituency seats in Parliament (325).
 So if a party has received 325 or more seats it can be declared the winner overall.
 
-Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 349.
+Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 649.
 
 The scoreboard should show:
 - The seats for each party


### PR DESCRIPTION
… scala technical assessments tasks.md file. Change from 349 to 649.

## What?
Change the number of effective voting MPs from 349 to 649 in the tasks.md file of the scala and golang technical assessments. This PR makes the number of effective voting MPs consistent with the other technical assessments.

## Why?
The current number of effective voting MPs on the scala and goland technical assessments is incorrect. The total number of MPs is 650, and so given that the speaker of the house does not vote, the number of effective voting MPs is 649, rather than 349.
