### PR TITLE
Small refactor of Java technical assessment method names, some tidying

### DIFF
--- a/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
+++ b/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
@@ -1,17 +1,13 @@
 package bbc.news.elections.controllers;
 
 import bbc.news.elections.model.ConstituencyResult;
-import bbc.news.elections.model.PartyResult;
 import bbc.news.elections.model.Scoreboard;
-import bbc.news.elections.service.NotImplementedException;
 import bbc.news.elections.service.ResultNotFoundException;
 import bbc.news.elections.service.ResultService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 public class ResultsController {
@@ -24,17 +20,17 @@ public class ResultsController {
 
     @GetMapping("/result/{id}")
     ConstituencyResult getResult(@PathVariable Integer id) {
-        ConstituencyResult result = resultService.GetResult(id);
+        ConstituencyResult result = resultService.getResult(id);
         if (result == null) {
             throw new ResultNotFoundException(id);
         }
-        return resultService.GetResult(id);
+        return resultService.getResult(id);
     }
 
     @PostMapping("/result")
     ResponseEntity<String> newResult(@RequestBody ConstituencyResult result) {
         if (result.getId() != null) {
-            resultService.NewResult(result);
+            resultService.newResult(result);
             return ResponseEntity.created(URI.create("/result/"+result.getId())).build();
         }
         return ResponseEntity.badRequest().body("Id was null");

--- a/election-api-java/src/main/java/bbc/news/elections/service/MapBasedRepository.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/MapBasedRepository.java
@@ -9,24 +9,24 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class MapBasedRepository implements ResultService {
 
-    private final Map<Integer,ConstituencyResult> results;
+    private final Map<Integer, ConstituencyResult> results;
 
     public MapBasedRepository() {
         results = new ConcurrentHashMap<>();
     }
 
     @Override
-    public ConstituencyResult GetResult(Integer id) {
+    public ConstituencyResult getResult(Integer id) {
         return results.get(id);
     }
 
     @Override
-    public void NewResult(ConstituencyResult result) {
+    public void newResult(ConstituencyResult result) {
         results.put(result.getId(), result);
     }
 
     @Override
-    public Map<Integer, ConstituencyResult> GetAll() {
+    public Map<Integer, ConstituencyResult> getAll() {
         return results;
     }
 

--- a/election-api-java/src/main/java/bbc/news/elections/service/NotImplementedException.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/NotImplementedException.java
@@ -1,4 +1,4 @@
 package bbc.news.elections.service;
 
-public class NotImplementedException  extends  RuntimeException {
+public class NotImplementedException extends RuntimeException {
 }

--- a/election-api-java/src/main/java/bbc/news/elections/service/ResultNotFoundException.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/ResultNotFoundException.java
@@ -1,6 +1,5 @@
 package bbc.news.elections.service;
 
-
 public class ResultNotFoundException extends RuntimeException {
     private Integer resultId;
 

--- a/election-api-java/src/main/java/bbc/news/elections/service/ResultService.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/ResultService.java
@@ -2,12 +2,11 @@ package bbc.news.elections.service;
 
 import bbc.news.elections.model.ConstituencyResult;
 
-import java.util.List;
 import java.util.Map;
 
 public interface ResultService {
-    ConstituencyResult GetResult(Integer id);
-    void NewResult(ConstituencyResult result);
-    Map<Integer,ConstituencyResult> GetAll();
+    ConstituencyResult getResult(Integer id);
+    void newResult(ConstituencyResult result);
+    Map<Integer,ConstituencyResult> getAll();
     void reset();
 }


### PR DESCRIPTION
## What?
Refactors within the Java technical assessment:
- Refactor Java method names to start with a lowercase letter instead of a capitalised letter
- remove some unneeded whitespace
- remove some unused imports

## Why?
- Java method naming conventions are such that methods should start with a lowercase letter. These methods may be easier to read for candidates now that they follow the expected Java naming conventions
- removal of whitespace and imports is just to keep the codebase as tidy as possible
