### PR TITLE
Upgrade sbt to 1.7.2

### DIFF
--- a/election-api-scala/project/build.properties
+++ b/election-api-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.2


### PR DESCRIPTION
## What?
Upgrade the SBT version from 1.5.2 to 1.7.2

## Why?
Keep-up with security fixes to the SBT build tool, alongside enhanced support for Scala 2.13.x projects