### PR TITLE
Pin Spring Boot to v2.7.7

### DIFF
--- a/election-api-java/pom.xml
+++ b/election-api-java/pom.xml
@@ -9,6 +9,9 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+
+        <!-- pin to v2 as v3 is compiled with java 17 -->
+        <spring-boot-version>2.7.7</spring-boot-version>
     </properties>
 
     <dependencyManagement>
@@ -16,7 +19,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.6.6</version>
+                <version>${spring-boot-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -27,10 +30,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring-boot-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -40,6 +45,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What?
Specify the version (2.77) of Spring Boot to use.

## Why?
When unspecified (e.g. as was the `spring-maven-plugin` dependency) it uses the latest version, which is 3.  Version 3 is compiled with Java 17 and `spring-maven-plugin` throws this error when building with Maven in Java 11:

`org/springframework/boot/maven/RunMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0 `

This is an interim change before upgrading the assessment to Java 17.