### PR TITLE
[election-api-js]: Clarify test comments

### DIFF
--- a/election-api-javascript/test/scoreboard.spec.js
+++ b/election-api-javascript/test/scoreboard.spec.js
@@ -33,48 +33,48 @@ describe('Scoreboard Tests', () => {
         await loadResults(server, 5);
         const scoreboard = await fetchScoreboard(server);
         expect(scoreboard).not.toBeNull();
-        // assert LD == 1
-        // assert LAB = 4
-        // assert winner = noone
+        // assert LD  have won 1 seat
+        // assert LAB have won 4 seats
+        // assert no winner
     });
 
     test('first 100', async () => {
         await loadResults(server, 100);
         const scoreboard = await fetchScoreboard(server);
         expect(scoreboard).not.toBeNull();
-        // assert LD == 12
-        // assert LAB == 56
-        // assert CON == 31
-        // assert SGP == 0
-        // assert winner = noone
+        // assert LD  have won 12 seats
+        // assert LAB have won 56 seats
+        // assert CON have won 31 seats
+        // assert SGP have won 0  seats
+        // assert no winner
         // Bonus Task (total votes):
-        // assert SGP == 1071
+        // assert SGP have 1071 votes in total
     });
 
     test('first 554', async () => {
         await loadResults(server, 554);
         const scoreboard = await fetchScoreboard(server);
         expect(scoreboard).not.toBeNull();
-        // assert LD == 52
-        // assert LAB = 325
-        // assert CON = 167
-        // assert IKHH = 1
-        // assert winner = LAB
+        // assert LD   have won 52  seats
+        // assert LAB  have won 325 seats
+        // assert CON  have won 167 seats
+        // assert IKHH have won 1   seats
+        // assert winner is LAB
         // Bonus Task (total votes):
-        // assert IKHH == 18739
+        // assert IKHH have 18739 votes in total
     });
 
     test('test all results', async () => {
         await loadResults(server, 650);
         const scoreboard = await fetchScoreboard(server);
         expect(scoreboard).not.toBeNull();
-        // assert LD == 62
-        // assert LAB == 349
-        // assert CON == 210
-        // assert SDLP == 3
-        // assert winner = LAB
-        // assert sum = 650
+        // assert LD   have won 62  seats
+        // assert LAB  have won 349 seats
+        // assert CON  have won 210 seats
+        // assert SDLP have won 3   seats
+        // assert winner is LAB
+        // assert 650 seats counted
         // Bonus Task (total votes):
-        // assert SDLP == 125626
+        // assert SDLP have 125626 votes in total
     });
 });


### PR DESCRIPTION
## What?

Clarify what assertions we are expecting in the JS API tests and use natural language rather than code symbols.

## Why?

The use of `=` and `==` in the testing comments has caused some confusion for some candidates 
