### PR TITLE
[election-ui-js] Use React-18-compatible ReactDOM code

### DIFF
--- a/election-ui-javascript/package-lock.json
+++ b/election-ui-javascript/package-lock.json
@@ -15775,9 +15775,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -28012,9 +28012,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/election-ui-javascript/src/index.js
+++ b/election-ui-javascript/src/index.js
@@ -1,11 +1,14 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import Scoreboard from './components/Scoreboard';
+import React from "react";
+import * as ReactDOMClient from "react-dom/client";
+import "./index.css";
+import Scoreboard from "./components/Scoreboard";
 
-ReactDOM.render(
+const root = ReactDOMClient.createRoot(
+  document.getElementById("root")
+);
+
+root.render(
   <React.StrictMode>
     <Scoreboard />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
## What?

- `ReactDOM.render()` doesn't support React 18 (see these docs: https://github.com/reactwg/react-18/discussions/5)
- Update to the new pattern described in the docs

## Why?

- Without this, we'll be running in a "legacy" React 17 mode and confusing messages are logged to the console in the browser.
