### PR TITLE
general improvements to python exercise

### DIFF
--- a/election-api-python/src/results_controller.py
+++ b/election-api-python/src/results_controller.py
@@ -4,17 +4,17 @@ class ResultsController:
 
     def __init__(self) -> None:
         self.store: ResultStore = ResultStore()
-    
-    def get_result(self, id: int) -> dict:
-        return self.store.get_result(id)
-    
+
+    def get_result(self, identifier: int) -> dict:
+        return self.store.get_result(identifier)
+
     def new_result(self, result: dict) -> dict:
         self.store.new_result(result)
         return {}
-    
+
     def reset(self) -> None:
         self.store.reset()
-    
+
     def scoreboard(self) -> dict:
         # Left blank for you to fill in
         return {}

--- a/election-api-python/src/server.py
+++ b/election-api-python/src/server.py
@@ -5,8 +5,8 @@ app: Flask = Flask(__name__)
 controller: ResultsController = ResultsController()
 
 @app.route("/result/<id>", methods=["GET"])
-def individual_result(id) -> dict:
-    return controller.get_result(int(id))
+def individual_result(identifier) -> dict:
+    return controller.get_result(int(identifier))
 
 @app.route("/result", methods=["POST"])
 def add_result() -> dict:

--- a/election-api-python/src/server.py
+++ b/election-api-python/src/server.py
@@ -15,4 +15,8 @@ def add_result() -> dict:
 @app.route("/scoreboard", methods=["GET"])
 def scoreboard() -> dict:
     return controller.scoreboard()
-    
+
+@app.errorhandler(Exception)
+def all_exception_handler(e):
+    print(f"[ERROR] - exception ({type(e).__name__}) occurred during request handling: {e}")
+    return {}, 500

--- a/election-api-python/src/test_scoreboard.py
+++ b/election-api-python/src/test_scoreboard.py
@@ -24,16 +24,20 @@ class TestScoreboard(unittest.TestCase):
             results.append(self.load_and_post_result_file(i + 1))
         return results
 
-    def fetch_scoreboard(self) -> list[dict]:
+    def fetch_scoreboard(self) -> tuple[int, dict]: # returns (status_code, response_body_object)
         response = self.server.get("/scoreboard")
-        return [] if response.data == b'{}\n' else json.loads(response.data.decode("utf-8"))
+        return (response.status_code, json.loads(response.data.decode("utf-8")))
 
     def setUp(self) -> None:
         controller.reset()
 
     def test_first_5(self) -> None:
         self.load_results(5)
-        scoreboard: list = self.fetch_scoreboard()
+        status_code, scoreboard = self.fetch_scoreboard()
+
+        if status_code != 200:
+            self.fail(f"non-200 status code received: {status_code}")
+
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 1
 		# assert LAB = 4
@@ -41,7 +45,11 @@ class TestScoreboard(unittest.TestCase):
 
     def test_first_100(self) -> None:
         self.load_results(100)
-        scoreboard: list = self.fetch_scoreboard()
+        status_code, scoreboard = self.fetch_scoreboard()
+
+        if status_code != 200:
+            self.fail(f"non-200 status code received: {status_code}")
+
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 12
 		# assert LAB == 56
@@ -50,7 +58,11 @@ class TestScoreboard(unittest.TestCase):
 
     def test_first_554(self) -> None:
         self.load_results(554)
-        scoreboard: list = self.fetch_scoreboard()
+        status_code, scoreboard = self.fetch_scoreboard()
+
+        if status_code != 200:
+            self.fail(f"non-200 status code received: {status_code}")
+
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 52
 		# assert LAB = 325
@@ -59,7 +71,11 @@ class TestScoreboard(unittest.TestCase):
 
     def test_all_results(self) -> None:
         self.load_results(650)
-        scoreboard: list = self.fetch_scoreboard()
+        status_code, scoreboard = self.fetch_scoreboard()
+
+        if status_code != 200:
+            self.fail(f"non-200 status code received: {status_code}")
+
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 62
 		# assert LAB == 349

--- a/election-api-python/src/test_scoreboard.py
+++ b/election-api-python/src/test_scoreboard.py
@@ -1,4 +1,7 @@
-import unittest, json, os
+import unittest
+import json
+import os
+
 from server import app, controller
 
 class TestScoreboard(unittest.TestCase):
@@ -11,7 +14,7 @@ class TestScoreboard(unittest.TestCase):
 
     def load_and_post_result_file(self, num: str) -> dict:
         file_number: str = str(num).zfill(3)
-        with open(f"{self.RESULT_SAMPLE_PATH}/result{file_number}.json", "r") as file:
+        with open(f"{self.RESULT_SAMPLE_PATH}/result{file_number}.json", "r", encoding="utf-8") as file:
             result = file.read()
         return self.server.post("/result", json=json.loads(result))
 
@@ -20,7 +23,7 @@ class TestScoreboard(unittest.TestCase):
         for i in range(quantity):
             results.append(self.load_and_post_result_file(i + 1))
         return results
-    
+
     def fetch_scoreboard(self) -> list[dict]:
         response = self.server.get("/scoreboard")
         return [] if response.data == b'{}\n' else json.loads(response.data.decode("utf-8"))

--- a/election-api-python/src/test_scoreboard.py
+++ b/election-api-python/src/test_scoreboard.py
@@ -35,9 +35,7 @@ class TestScoreboard(unittest.TestCase):
         self.load_results(5)
         status_code, scoreboard = self.fetch_scoreboard()
 
-        if status_code != 200:
-            self.fail(f"non-200 status code received: {status_code}")
-
+        self.assertEqual(status_code, 200, f"non-200 status code received: {status_code}")
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 1
 		# assert LAB = 4
@@ -47,9 +45,7 @@ class TestScoreboard(unittest.TestCase):
         self.load_results(100)
         status_code, scoreboard = self.fetch_scoreboard()
 
-        if status_code != 200:
-            self.fail(f"non-200 status code received: {status_code}")
-
+        self.assertEqual(status_code, 200, f"non-200 status code received: {status_code}")
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 12
 		# assert LAB == 56
@@ -60,9 +56,7 @@ class TestScoreboard(unittest.TestCase):
         self.load_results(554)
         status_code, scoreboard = self.fetch_scoreboard()
 
-        if status_code != 200:
-            self.fail(f"non-200 status code received: {status_code}")
-
+        self.assertEqual(status_code, 200, f"non-200 status code received: {status_code}")
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 52
 		# assert LAB = 325
@@ -73,9 +67,7 @@ class TestScoreboard(unittest.TestCase):
         self.load_results(650)
         status_code, scoreboard = self.fetch_scoreboard()
 
-        if status_code != 200:
-            self.fail(f"non-200 status code received: {status_code}")
-
+        self.assertEqual(status_code, 200, f"non-200 status code received: {status_code}")
         self.assertNotEqual(len(scoreboard), 0)
         # assert LD == 62
 		# assert LAB == 349


### PR DESCRIPTION
## What?
several changes (detailed below) to the python exercise based primarily on where I've seen candidates trip up in the past

- renamed `id` to `identifier` ([`id`](https://docs.python.org/3/library/functions.html#id) is a built-in function in python that we shouldn't overwrite)
- modified the behaviour of `fetch_scoreboard` in `test_scoreboard.py`
  - previously this method had the behaviour of returning an empty list if the server responded with an empty dictionary, leading to candidates becoming confused about the expected return type
  - now this method returns a tuple of the status code and parsed response body (reasons for this detailed below)
- changed the behaviour of the application when exceptions are raised
  - currently when exceptions occur in the implementation, the tests will result in another exception due to attempting to parse a JSON response body that no longer exists 
    - from experience this results in candidates becoming confused as the true exception is drowned out by JSON decode errors (see before/after example at the bottom of this PR)
  - this behaviour has been modified with the introducing of a flask error handling that catches all exceptions, logs them out, and instead returns an empty JSON body with a 500 status code
  - each test has been modified to assert on the status code of the response
  
### before/after exception changes
#### before
```
MC-N385402:election-api-python chesta02$ python src/test_scoreboard.py
[2024-07-18 15:01:20,098] ERROR in app: Exception on /scoreboard [GET]
Traceback (most recent call last):
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/workspace/software-engineering-technical-assessments/election-api-python/src/server.py", line 17, in scoreboard
    return controller.scoreboard()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/workspace/software-engineering-technical-assessments/election-api-python/src/results_controller.py", line 20, in scoreboard
    raise KeyError("foo")
KeyError: 'foo'
E
======================================================================
ERROR: test_first_5 (__main__.TestScoreboard.test_first_5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/chesta02/workspace/software-engineering-technical-assessments/election-api-python/src/test_scoreboard.py", line 33, in test_first_5
    scoreboard: list = self.fetch_scoreboard()
                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/workspace/software-engineering-technical-assessments/election-api-python/src/test_scoreboard.py", line 26, in fetch_scoreboard
    return [] if response.data == b'{}\n' else json.loads(response.data.decode("utf-8"))
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chesta02/.pyenv/versions/3.12.2/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

----------------------------------------------------------------------
Ran 1 test in 0.005s

FAILED (errors=1)
```

#### after
```
MC-N385402:election-api-python chesta02$ python ./src/test_scoreboard.py
[ERROR] - exception (KeyError) occurred during request handling: 'foo'
F
======================================================================
FAIL: test_first_5 (__main__.TestScoreboard.test_first_5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/chesta02/workspace/software-engineering-technical-assessments/election-api-python/./src/test_scoreboard.py", line 38, in test_first_5
    self.assertEqual(status_code, 200, f"non-200 status code received: {status_code}")
AssertionError: 500 != 200 : non-200 status code received: 500

----------------------------------------------------------------------
Ran 1 test in 0.004s

FAILED (failures=1)
```