### PR TITLE
Java camel case naming

### DIFF
--- a/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
+++ b/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
@@ -24,17 +24,17 @@ public class ResultsController {
 
     @GetMapping("/result/{id}")
     ConstituencyResult getResult(@PathVariable Integer id) {
-        ConstituencyResult result = resultService.GetResult(id);
+        ConstituencyResult result = resultService.getResult(id);
         if (result == null) {
             throw new ResultNotFoundException(id);
         }
-        return resultService.GetResult(id);
+        return resultService.getResult(id);
     }
 
     @PostMapping("/result")
     ResponseEntity<String> newResult(@RequestBody ConstituencyResult result) {
         if (result.getId() != null) {
-            resultService.NewResult(result);
+            resultService.newResult(result);
             return ResponseEntity.created(URI.create("/result/"+result.getId())).build();
         }
         return ResponseEntity.badRequest().body("Id was null");

--- a/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
+++ b/election-api-java/src/main/java/bbc/news/elections/controllers/ResultsController.java
@@ -28,7 +28,7 @@ public class ResultsController {
         if (result == null) {
             throw new ResultNotFoundException(id);
         }
-        return resultService.getResult(id);
+        return result;
     }
 
     @PostMapping("/result")

--- a/election-api-java/src/main/java/bbc/news/elections/service/MapBasedRepository.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/MapBasedRepository.java
@@ -16,17 +16,17 @@ public class MapBasedRepository implements ResultService {
     }
 
     @Override
-    public ConstituencyResult GetResult(Integer id) {
+    public ConstituencyResult getResult(Integer id) {
         return results.get(id);
     }
 
     @Override
-    public void NewResult(ConstituencyResult result) {
+    public void newResult(ConstituencyResult result) {
         results.put(result.getId(), result);
     }
 
     @Override
-    public Map<Integer, ConstituencyResult> GetAll() {
+    public Map<Integer, ConstituencyResult> getAll() {
         return results;
     }
 

--- a/election-api-java/src/main/java/bbc/news/elections/service/ResultService.java
+++ b/election-api-java/src/main/java/bbc/news/elections/service/ResultService.java
@@ -2,12 +2,11 @@ package bbc.news.elections.service;
 
 import bbc.news.elections.model.ConstituencyResult;
 
-import java.util.List;
 import java.util.Map;
 
 public interface ResultService {
-    ConstituencyResult GetResult(Integer id);
-    void NewResult(ConstituencyResult result);
-    Map<Integer,ConstituencyResult> GetAll();
+    ConstituencyResult getResult(Integer id);
+    void newResult(ConstituencyResult result);
+    Map<Integer,ConstituencyResult> getAll();
     void reset();
 }


### PR DESCRIPTION
## What?
Changed method names in `ResultService` and `MapBasedRepository` to use `camelCase` spelling. Plus a very small refactor
## Why?
To follow widespread Java convention for naming methods and prevent surprises for candidates.