### PR TITLE
fix incorrectly named variable

### DIFF
--- a/election-api-python/src/server.py
+++ b/election-api-python/src/server.py
@@ -4,7 +4,7 @@ from results_controller import ResultsController
 app: Flask = Flask(__name__)
 controller: ResultsController = ResultsController()
 
-@app.route("/result/<id>", methods=["GET"])
+@app.route("/result/<identifier>", methods=["GET"])
 def individual_result(identifier) -> dict:
     return controller.get_result(int(identifier))
 


### PR DESCRIPTION
## What?
fixed an incorrectly named variable in the route definition

## Why?
because currently it results in a bug when there are no results found - this isn't a problem for the "happy path" of running the tests, but if the candidate runs the server independently with no results added it won't serve the correct error message
