### PR TITLE
[election-ui-kotlin]: Update gradle, compile and target versions

### DIFF
--- a/election-ui-kotlin/appWithComposeUI/build.gradle
+++ b/election-ui-kotlin/appWithComposeUI/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "uk.co.bbc.elections"
         minSdk 21
-        targetSdk 32
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/election-ui-kotlin/appWithComposeUI/build.gradle
+++ b/election-ui-kotlin/appWithComposeUI/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         applicationId "uk.co.bbc.elections"

--- a/election-ui-kotlin/appWithXmlUI/build.gradle
+++ b/election-ui-kotlin/appWithXmlUI/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "uk.co.bbc.elections"
         minSdk 21
-        targetSdk 32
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/election-ui-kotlin/appWithXmlUI/build.gradle
+++ b/election-ui-kotlin/appWithXmlUI/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         applicationId "uk.co.bbc.elections"
@@ -15,6 +15,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    namespace "uk.co.bbc.elections"
 
     buildTypes {
         release {

--- a/election-ui-kotlin/build.gradle
+++ b/election-ui-kotlin/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.1' apply false
-    id 'com.android.library' version '7.2.1' apply false
+    id 'com.android.application' version '8.7.1' apply false
+    id 'com.android.library' version '8.7.1' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
 }
 

--- a/election-ui-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/election-ui-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 13 13:54:11 BST 2022
+#Thu Oct 24 16:23:15 BST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/election-ui-kotlin/settings.gradle
+++ b/election-ui-kotlin/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {

--- a/election-ui-kotlin/settings.gradle
+++ b/election-ui-kotlin/settings.gradle
@@ -5,10 +5,6 @@ pluginManagement {
         mavenCentral()
     }
 }
-
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
-}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
## What?
Updating some core dependencies and versions.
Gradle, gradle plugins, compileSdk and targetSdk.

## Why?
Updating gradle as the latest version of Android Studio (Ladybug) otherwise requires extra project configuration to compile as seen in this issue: https://stackoverflow.com/questions/79049863/android-studio-ladybug-your-build-is-currently-configured-to-use-incompatible-j 

compileSdk and targetSdk updated to keep things generally up to date and remove warning messages not particularly relevant to the exercise(Play Store requirements).