### PR TITLE
minor tweaks to the python api assessment

### DIFF
--- a/election-api-python/README.md
+++ b/election-api-python/README.md
@@ -29,12 +29,11 @@ __Warning:__  If you make any changes to the code, please ensure you return it t
 ### To Build
 `pip install -r requirements.txt`
 
+### To Test
+`python ./src/test_scoreboard.py`
+
 ### To Run
 `python ./src/main.py`
 
 or if you need to run it on another port,
 `PORT=**** python ./src/main.py`
-
-### To Test
-`python ./src/test_scoreboard.py`
-

--- a/election-api-python/src/results_controller.py
+++ b/election-api-python/src/results_controller.py
@@ -3,17 +3,17 @@ from results_service import ResultStore
 class ResultsController:
 
     def __init__(self) -> None:
-        self.store: ResultStore = ResultStore()
+        self.result_store: ResultStore = ResultStore()
 
     def get_result(self, identifier: int) -> dict:
-        return self.store.get_result(identifier)
+        return self.result_store.get_result(identifier)
 
     def new_result(self, result: dict) -> dict:
-        self.store.new_result(result)
+        self.result_store.new_result(result)
         return {}
 
     def reset(self) -> None:
-        self.store.reset()
+        self.result_store.reset()
 
     def scoreboard(self) -> dict:
         # Left blank for you to fill in


### PR DESCRIPTION
## What?
A couple of minor tweaks to the python api assessment based on my experiences watching candidates attempt it

- renamed `store` to `result_store` in `ResultsController`
    - `store` is also what the `ResultStore` calls its internal data store, and I've seen candidates trip themselves up on occasion mistaking the two
- changed the README ordering so that test instructions appear before running instructions
    - I've seen more than one candidate get hung up on trying to get the server running to debug things, which doesn't help because the server doesn't have any data in unless you POST some data to it (e.g. https://github.com/bbc/software-engineering-technical-assessments/blob/a5264306388176e481893b73e9dd0055b31ab99e/election-api-python/src/test_scoreboard.py#L15-L19)
    - Given the limited time in assessment centres I feel we can evaluate candidates better by discouraging actually running the server somewhat