### PR TITLE
[election-ui-kotlin] - Work better with edge to edge enabled

### DIFF
--- a/election-ui-kotlin/appWithComposeUI/build.gradle
+++ b/election-ui-kotlin/appWithComposeUI/build.gradle
@@ -27,18 +27,14 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(java_version)
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion "1.5.15"
+        kotlinCompilerExtensionVersion kotlin_compiler_version
     }
     packagingOptions {
         resources {

--- a/election-ui-kotlin/appWithComposeUI/build.gradle
+++ b/election-ui-kotlin/appWithComposeUI/build.gradle
@@ -28,18 +28,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
-        freeCompilerArgs += "-Xjvm-default=enable"
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
+        kotlinCompilerExtensionVersion "1.5.15"
     }
     packagingOptions {
         resources {
@@ -54,6 +53,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$androidx_core_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidx_lifecycle_version"
     implementation "androidx.activity:activity-compose:$androidx_activity_compose_version"

--- a/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/MainActivity.kt
+++ b/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/MainActivity.kt
@@ -3,10 +3,12 @@ package uk.co.bbc.elections.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import uk.co.bbc.elections.ElectionsApplication
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
             App((application as ElectionsApplication).serviceContainer)

--- a/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Home.kt
+++ b/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Home.kt
@@ -1,7 +1,8 @@
 package uk.co.bbc.elections.ui.home
 
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.FloatingActionButton
@@ -38,7 +39,8 @@ fun Home(uiState: HomeUiState, refresh: () -> Unit) = Scaffold(
     LazyColumn(
         Modifier
             .padding(innerPadding)
-            .fillMaxSize()
+            .consumeWindowInsets(innerPadding)
+            .safeDrawingPadding(),
     ) {
         item { ResultHeader() }
         items(uiState.results) { Result(it) }

--- a/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Home.kt
+++ b/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Home.kt
@@ -28,7 +28,10 @@ fun Home(viewModel: HomeViewModel) {
 @Composable
 fun Home(uiState: HomeUiState, refresh: () -> Unit) = Scaffold(
     floatingActionButton = {
-        FloatingActionButton(onClick = { if (!uiState.loading) refresh() }) {
+        FloatingActionButton(
+            onClick = { if (!uiState.loading) refresh() },
+            modifier = Modifier.safeDrawingPadding()
+        ) {
             Icon(
                 imageVector = Icons.Filled.Refresh,
                 contentDescription = stringResource(id = R.string.refresh)
@@ -40,7 +43,7 @@ fun Home(uiState: HomeUiState, refresh: () -> Unit) = Scaffold(
         Modifier
             .padding(innerPadding)
             .consumeWindowInsets(innerPadding)
-            .safeDrawingPadding(),
+            .safeDrawingPadding()
     ) {
         item { ResultHeader() }
         items(uiState.results) { Result(it) }

--- a/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Result.kt
+++ b/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/Result.kt
@@ -2,15 +2,19 @@ package uk.co.bbc.elections.ui.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun Result(result: ResultUiState) = Row(
-    modifier = Modifier.background(MaterialTheme.colors.surface)
+    modifier = Modifier
+        .background(MaterialTheme.colors.surface)
+        .padding(8.dp)
 ) {
     Text(
         modifier = Modifier.weight(1f),

--- a/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/ResultHeader.kt
+++ b/election-ui-kotlin/appWithComposeUI/src/main/java/uk/co/bbc/elections/ui/home/ResultHeader.kt
@@ -2,16 +2,22 @@ package uk.co.bbc.elections.ui.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import uk.co.bbc.elections.R
 
 @Composable
-fun ResultHeader() = Row(modifier = Modifier.background(MaterialTheme.colors.primary)) {
+fun ResultHeader() = Row(
+    modifier = Modifier
+        .background(MaterialTheme.colors.primary)
+        .padding(8.dp)
+) {
     Text(
         modifier = Modifier.weight(1f),
         text = stringResource(id = R.string.results_header_party).uppercase()

--- a/election-ui-kotlin/appWithXmlUI/build.gradle
+++ b/election-ui-kotlin/appWithXmlUI/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -25,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         viewBinding true
@@ -40,6 +42,7 @@ dependencies {
     implementation project(":api")
 
     implementation "androidx.core:core-ktx:$androidx_core_version"
+    implementation "androidx.activity:activity-ktx:$androidx_activity_version"
     implementation "androidx.fragment:fragment-ktx:$androidx_fragment_version"
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "com.google.android.material:material:$material_version"
@@ -56,7 +59,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidx_test_espresso_version"
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
         freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }

--- a/election-ui-kotlin/appWithXmlUI/build.gradle
+++ b/election-ui-kotlin/appWithXmlUI/build.gradle
@@ -26,12 +26,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(java_version)
     }
     buildFeatures {
         viewBinding true

--- a/election-ui-kotlin/appWithXmlUI/src/main/java/uk/co/bbc/elections/MainActivity.kt
+++ b/election-ui-kotlin/appWithXmlUI/src/main/java/uk/co/bbc/elections/MainActivity.kt
@@ -2,11 +2,13 @@ package uk.co.bbc.elections
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import uk.co.bbc.elections.ui.results.ResultsFragment
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         if (savedInstanceState == null) {

--- a/election-ui-kotlin/appWithXmlUI/src/main/java/uk/co/bbc/elections/ui/results/ResultsFragment.kt
+++ b/election-ui-kotlin/appWithXmlUI/src/main/java/uk/co/bbc/elections/ui/results/ResultsFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -41,8 +44,25 @@ class ResultsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setWindowInsets(view)
         prepareViews()
         observeViewModel()
+    }
+
+    private fun setWindowInsets(view: View) {
+        setOnApplyWindowInsetsListener(view) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars()
+                        or WindowInsetsCompat.Type.displayCutout()
+            )
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
     }
 
     private fun prepareViews() {

--- a/election-ui-kotlin/build.gradle
+++ b/election-ui-kotlin/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext {
+        java_version = 11
         androidx_activity_compose_version = '1.9.3'
         androidx_activity_version = '1.9.3'
         androidx_appcompat_version = '1.7.0'
@@ -12,6 +13,7 @@ buildscript {
         compose_version = '1.7.5'
         junit_version = '4.13.2'
         kotlin_version = '1.9.25'
+        kotlin_compiler_version = '1.5.15'
         kotlinx_coroutines_version = '1.6.2'
         kotlinx_serialization_version = '1.3.3'
         material_version = '1.12.0'

--- a/election-ui-kotlin/build.gradle
+++ b/election-ui-kotlin/build.gradle
@@ -1,24 +1,25 @@
 buildscript {
     ext {
-        androidx_activity_compose_version = '1.5.0'
-        androidx_appcompat_version = '1.4.2'
-        androidx_constraintlayout_version = '2.1.4'
-        androidx_core_version = '1.8.0'
-        androidx_fragment_version = '1.4.1'
-        androidx_lifecycle_version = '2.5.0'
-        androidx_test_espresso_version = '3.4.0'
-        androidx_test_junit_version = '1.1.3'
-        compose_version = '1.1.1'
+        androidx_activity_compose_version = '1.9.3'
+        androidx_activity_version = '1.9.3'
+        androidx_appcompat_version = '1.7.0'
+        androidx_constraintlayout_version = '2.2.0'
+        androidx_core_version = '1.15.0'
+        androidx_fragment_version = '1.8.5'
+        androidx_lifecycle_version = '2.8.7'
+        androidx_test_espresso_version = '3.6.1'
+        androidx_test_junit_version = '1.2.1'
+        compose_version = '1.7.5'
         junit_version = '4.13.2'
-        kotlin_version = '1.6.10'
+        kotlin_version = '1.9.25'
         kotlinx_coroutines_version = '1.6.2'
         kotlinx_serialization_version = '1.3.3'
-        material_version = '1.6.1'
+        material_version = '1.12.0'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.7.1' apply false
-    id 'com.android.library' version '8.7.1' apply false
+    id 'com.android.application' version '8.7.3' apply false
+    id 'com.android.library' version '8.7.3' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
 }
 


### PR DESCRIPTION
## What?
_Have the Kotlin apps work on Android 15 where edge to edge is enabled by default_

_Plus a few dependency updates_

## Why?

The UI was being drawn behind insets on the device such as camera / speaker.  These changes pad the content so the UI is only drawn in safe UI spaces.

Screenshots before changes (xml left, compose right):
<img width="150" alt="Screenshot 2024-12-11 at 22 26 15" src="https://github.com/user-attachments/assets/1d608b24-4e6f-4e4f-90a8-f0bb0b088ede" /> <img width="150" alt="Screenshot 2024-12-11 at 22 27 28" src="https://github.com/user-attachments/assets/c2bde5bc-5581-4798-881c-0326aa8ae0fe" />

After changes (xml left, compose right):
<img width="150" alt="Screenshot 2024-12-11 at 22 28 32" src="https://github.com/user-attachments/assets/dc5fd02c-e0d6-457b-8dd2-fccb08c07742" /> <img width="150" alt="Screenshot 2024-12-16 at 13 56 47" src="https://github.com/user-attachments/assets/26e44f1a-ca78-47e2-923a-3297fea5bf90" />


